### PR TITLE
change in comparisons in lines 81 and 132

### DIFF
--- a/matlab/calcVelocity.m
+++ b/matlab/calcVelocity.m
@@ -78,7 +78,7 @@ surface(y,x) = t;
 if(p == -1)
     surfPos(y,x) = t; % assign incoming event to positive SAE
     % check if pixel in imageFrame, depending on window size N  
-    if(((IMAGE_FRAME(1)-floor(N/2)>=x) && (x>=ceil(N/2))) && ((IMAGE_FRAME(2)-floor(N/2)>=y) && (y>=ceil(N/2))))
+    if(((IMAGE_FRAME(1)-floor(N/2)>=y) && (y>=ceil(N/2))) && ((IMAGE_FRAME(2)-floor(N/2)>=x) && (x>=ceil(N/2))))
         % read out local NxN surface window
         data = surfPos((y-floor(N/2)):(y+floor(N/2)),...
                        (x-floor(N/2)):(x+floor(N/2)));
@@ -129,7 +129,7 @@ end
 if(p == 1)
     surfNeg(y,x) = t; % assign incoming event to negative SAE
     % check if pixel in imageFrame, depending on window size N  
-   if(((IMAGE_FRAME(1)-floor(N/2)>=x) && (x>=ceil(N/2))) && ((IMAGE_FRAME(2)-floor(N/2)>=y) && (y>=ceil(N/2))))
+   if(((IMAGE_FRAME(1)-floor(N/2)>=y) && (y>=ceil(N/2))) && ((IMAGE_FRAME(2)-floor(N/2)>=x) && (x>=ceil(N/2))))
         % read out local NxN surface window
         data = surfNeg((y-floor(N/2)):(y+floor(N/2)),...
                        (x-floor(N/2)):(x+floor(N/2))); 


### PR DESCRIPTION
The comparison scheme implemented in earlier code would result in an out of bounds error. It was not apparent  in the code because the dimensions of the camera being used were symmetric(128x128). However, in the case of a 240x180 camera's event data, the code would throw an error. 
Proposed change looks to rectify this discrepancy.